### PR TITLE
feat: allow JS or TS files

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -53,7 +53,22 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
       const fnName = _.last(h.split('.'))
       const fnNameLastAppearanceIndex = h.lastIndexOf(fnName)
       // replace only last instance to allow the same name for file and handler
-      return h.substring(0, fnNameLastAppearanceIndex) + 'ts'
+      // return h.substring(0, fnNameLastAppearanceIndex) + 'ts'
+      const fileName = h.substring(0, fnNameLastAppearanceIndex)
+ 
+      // Check if the .ts files exists. If so return that to watch
+      if (fs.existsSync(path.join(cwd, fileName + 'ts'))) {
+          return fileName + 'ts'
+      }
+  
+      // Check if the .js files exists. If so return that to watch
+      if (fs.existsSync(path.join(cwd, fileName + 'js'))) {
+          return fileName + 'js'
+      }
+  
+      // Can't find the files. Watch will have an exception anyway. So throw one with error.
+      console.log(`Cannot locate handler - ${fileName} not found`)
+      throw new Error('Typescript compilation failed. Please ensure handlers exists with ext .ts or .js')
     })
 }
 


### PR DESCRIPTION
Fixes
```bash
Serverless: Using local tsconfig.json
{ file: undefined,
  start: undefined,
  length: undefined,
  messageText: 'File \'myfunction.ts\' not found.',
  category: 1,
  code: 6053 }

  Type Error ---------------------------------------------

  Cannot read property 'getLineAndCharacterOfPosition' of undefined

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
```